### PR TITLE
Add missing depends_on("py-setuptools", type="build")

### DIFF
--- a/var/spack/repos/builtin/packages/py-art/package.py
+++ b/var/spack/repos/builtin/packages/py-art/package.py
@@ -16,4 +16,5 @@ class PyArt(PythonPackage):
 
     version("6.1", sha256="6ab3031e3b7710039e73497b0e750cadfe04d4c1279ce3a123500dbafb9e1b64")
 
-    depends_on("python@3.5:")
+    depends_on("python@3.5:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-pycm/package.py
+++ b/var/spack/repos/builtin/packages/py-pycm/package.py
@@ -18,3 +18,4 @@ class PyPycm(PythonPackage):
 
     depends_on("py-art@1.8:", type=("build", "run"))
     depends_on("py-numpy@1.9.0:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
For https://github.com/ChristopherChristofi:

To be able to build "py-pycm: add new package with version 4.0" from https://github.com/spack/spack/pull/43251, I needed to add depends_on("py-setuptools", type="build") to it and py-art.

I copied the changes in this incremental PR from other packages, so I think it is fine to approve and merge this change onto your https://github.com/spack/spack/pull/43251 using this PR.

I am a spack maintainer in the group who can approve and merge to master, so with this merged, I'd be ready to approve your PR.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
